### PR TITLE
Run $lines through array_filter() to remove empty strings that can cause unhandled exceptions

### DIFF
--- a/src/AbstractPasswordExposedChecker.php
+++ b/src/AbstractPasswordExposedChecker.php
@@ -141,7 +141,7 @@ abstract class AbstractPasswordExposedChecker implements PasswordExposedCheckerI
         $hash = strtoupper($hash);
         $hashSuffix = substr($hash, 5);
 
-        $lines = explode("\r\n", $responseBody);
+        $lines = array_filter(explode("\r\n", $responseBody));
 
         foreach ($lines as $line) {
             list($exposedHashSuffix, $occurrences) = explode(':', $line);


### PR DESCRIPTION
incorporate fix from https://github.com/DivineOmega/password_exposed/pull/36

see https://github.com/DivineOmega/password_exposed/issues/35